### PR TITLE
Migrated Java Serialization

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,12 +2,8 @@
 java = "11"
 kotlin = "1.9.21"
 
-[libraries]
-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version = "1.6.2" }
-
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-samReceiver = { id = "org.jetbrains.kotlin.plugin.sam.with.receiver", version.ref = "kotlin" }
-kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 gradle-pluginPublish = { id = "com.gradle.plugin-publish", version = "1.2.1" }
 testkit-jacoco = { id = "pl.droidsonroids.jacoco.testkit", version = "1.0.12" }

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -3,7 +3,6 @@ import java.lang.Thread.sleep
 plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.kotlin.samReceiver)
-    alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.gradle.pluginPublish)
     alias(libs.plugins.testkit.jacoco)
 }
@@ -34,7 +33,6 @@ gradlePlugin {
 
 dependencies {
     compileOnly(gradleKotlinDsl())
-    implementation(libs.serialization.json)
     testImplementation(gradleKotlinDsl())
 }
 

--- a/plugin/src/main/kotlin/io/github/gmazzo/publications/report/ReportPublication.kt
+++ b/plugin/src/main/kotlin/io/github/gmazzo/publications/report/ReportPublication.kt
@@ -1,8 +1,7 @@
 package io.github.gmazzo.publications.report
 
-import kotlinx.serialization.Serializable
+import java.io.Serializable
 
-@Serializable
 data class ReportPublication(
     val groupId: String,
     val artifactId: String,
@@ -10,10 +9,9 @@ data class ReportPublication(
     val repository: Repository,
     val outcome: Outcome,
     val artifacts: List<String>,
-) {
+) : Serializable {
 
-    @Serializable
-    data class Repository(val name: String, val value: String)
+    data class Repository(val name: String, val value: String): Serializable
 
     enum class Outcome(text: String? = null) {
 

--- a/plugin/src/main/kotlin/io/github/gmazzo/publications/report/ReportPublicationSerializer.kt
+++ b/plugin/src/main/kotlin/io/github/gmazzo/publications/report/ReportPublicationSerializer.kt
@@ -1,0 +1,34 @@
+package io.github.gmazzo.publications.report
+
+import java.io.ByteArrayOutputStream
+import java.io.ObjectInputStream
+import java.io.ObjectOutputStream
+
+/**
+ * Short story about this class:
+ *
+ * The plugin supports included builds, but it requires to also get applied to them.
+ * As it's applied multiple times on different classloaders (one per root project), the classes loaded
+ * on each classloader are effectively different classes, and the reported (loaded at the main build) can't see them.
+ *
+ * As a workaround, we serialize the data when populating the [ReportPublication] collection, and
+ * we deserialize them before sending to the [ReportPublicationsFlowAction] reporter.
+ *
+ * The "right" way to address this classloader issue, will be to convert [ReportPublicationsPlugin]
+ * to a [org.gradle.api.initialization.Settings] plugin, as its classpath will be parent one of the included builds.
+ * This option was discarded because the extra complexity that [org.gradle.api.initialization.Settings] plugins have:
+ * 1) TOML is not supported for them
+ * 2) You need to define the plugin version on every settings `plugins` closure
+ */
+object ReportPublicationSerializer {
+
+    fun serialize(publication: ReportPublication) = with(ByteArrayOutputStream()) {
+        ObjectOutputStream(this).use { it.writeObject(publication) }
+        toByteArray()
+    }
+
+    fun deserialize(bytes: ByteArray) = bytes.inputStream().use {
+        ObjectInputStream(it).readObject() as ReportPublication
+    }
+
+}

--- a/plugin/src/main/kotlin/io/github/gmazzo/publications/report/ReportPublicationsFlowAction.kt
+++ b/plugin/src/main/kotlin/io/github/gmazzo/publications/report/ReportPublicationsFlowAction.kt
@@ -59,7 +59,7 @@ abstract class ReportPublicationsFlowAction : FlowAction<ReportPublicationsFlowA
                 identifier.text(it.groupId)
                 text(":${it.artifactId}:")
                 info.text(it.version)
-                failure.text(it.artifacts.joinToString(prefix = " ", separator = " "))
+                failure.text(it.artifacts.joinToString(prefix = " [", separator = ", ", postfix = "]"))
                 if (it.outcome != ReportPublication.Outcome.Published) {
                     failureHeader.text(" (${it.outcome.text})")
                 }

--- a/plugin/src/main/kotlin/io/github/gmazzo/publications/report/ReportPublicationsPlugin.kt
+++ b/plugin/src/main/kotlin/io/github/gmazzo/publications/report/ReportPublicationsPlugin.kt
@@ -9,6 +9,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.flow.FlowProviders
 import org.gradle.api.flow.FlowScope
+import org.gradle.api.internal.GradleInternal
 import org.gradle.api.invocation.Gradle
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.publish.maven.MavenArtifact
@@ -102,7 +103,7 @@ class ReportPublicationsPlugin @Inject constructor(
     private val Gradle.path: String
         get() = when (val parent = parent) {
             null -> ""
-            else -> "${parent.path}:${rootProject.name}"
+            else -> "${parent.path}${(this as GradleInternal).identityPath}"
         }
 
 }

--- a/plugin/src/test/kotlin/io/github/gmazzo/gradle/publications/report/ReportPublicationsPluginTest.kt
+++ b/plugin/src/test/kotlin/io/github/gmazzo/gradle/publications/report/ReportPublicationsPluginTest.kt
@@ -24,12 +24,12 @@ class ReportPublicationsPluginTest {
         assertEquals(
             """
             The following artifacts were published to myRepo(file:$rootDir/publish/build-logic/build/repo/):
-             - io.gmazzo.demo.build-logic:build-logic:0.1.0 jar
-             - io.gmazzo.demo.build-logic:otherModule:0.1.0 jar
+             - io.gmazzo.demo.build-logic:build-logic:0.1.0 [jar]
+             - io.gmazzo.demo.build-logic:otherModule:0.1.0 [jar]
             The following artifacts were published to myRepo(file:$rootDir/publish/build/repo/):
-             - io.gmazzo.demo:demo:0.1.0 jar
-             - io.gmazzo.demo:module1:0.1.0 jar
-             - io.gmazzo.demo:module2:0.1.0 jar
+             - io.gmazzo.demo:demo:0.1.0 [jar]
+             - io.gmazzo.demo:module1:0.1.0 [jar]
+             - io.gmazzo.demo:module2:0.1.0 [jar]
         """.trimIndent(), result.reportPublicationsOutput
         )
     }
@@ -44,11 +44,11 @@ class ReportPublicationsPluginTest {
         assertEquals(
             """
             The following artifacts were published to mavenLocal(~/.m2/repository):
-             - io.gmazzo.demo:demo:0.1.0 jar
-             - io.gmazzo.demo:module1:0.1.0 jar
-             - io.gmazzo.demo:module2:0.1.0 jar
-             - io.gmazzo.demo.build-logic:build-logic:0.1.0 jar
-             - io.gmazzo.demo.build-logic:otherModule:0.1.0 jar
+             - io.gmazzo.demo:demo:0.1.0 [jar]
+             - io.gmazzo.demo:module1:0.1.0 [jar]
+             - io.gmazzo.demo:module2:0.1.0 [jar]
+             - io.gmazzo.demo.build-logic:build-logic:0.1.0 [jar]
+             - io.gmazzo.demo.build-logic:otherModule:0.1.0 [jar]
         """.trimIndent(), result.reportPublicationsOutput
         )
     }
@@ -63,18 +63,18 @@ class ReportPublicationsPluginTest {
         assertEquals(
             """
             The following artifacts were published to myRepo(file:$rootDir/publish-publishToMavenLocal/build-logic/build/repo/):
-             - io.gmazzo.demo.build-logic:build-logic:0.1.0 jar
-             - io.gmazzo.demo.build-logic:otherModule:0.1.0 jar
+             - io.gmazzo.demo.build-logic:build-logic:0.1.0 [jar]
+             - io.gmazzo.demo.build-logic:otherModule:0.1.0 [jar]
             The following artifacts were published to myRepo(file:$rootDir/publish-publishToMavenLocal/build/repo/):
-             - io.gmazzo.demo:demo:0.1.0 jar
-             - io.gmazzo.demo:module1:0.1.0 jar
-             - io.gmazzo.demo:module2:0.1.0 jar
+             - io.gmazzo.demo:demo:0.1.0 [jar]
+             - io.gmazzo.demo:module1:0.1.0 [jar]
+             - io.gmazzo.demo:module2:0.1.0 [jar]
             The following artifacts were published to mavenLocal(~/.m2/repository):
-             - io.gmazzo.demo:demo:0.1.0 jar
-             - io.gmazzo.demo:module1:0.1.0 jar
-             - io.gmazzo.demo:module2:0.1.0 jar
-             - io.gmazzo.demo.build-logic:build-logic:0.1.0 jar
-             - io.gmazzo.demo.build-logic:otherModule:0.1.0 jar
+             - io.gmazzo.demo:demo:0.1.0 [jar]
+             - io.gmazzo.demo:module1:0.1.0 [jar]
+             - io.gmazzo.demo:module2:0.1.0 [jar]
+             - io.gmazzo.demo.build-logic:build-logic:0.1.0 [jar]
+             - io.gmazzo.demo.build-logic:otherModule:0.1.0 [jar]
         """.trimIndent(), result.reportPublicationsOutput
         )
     }


### PR DESCRIPTION
Dropped `kotlinx.serialization` in favor of just `ObjectOutputStream/ObjectInputStream` to reduce the complexity and dependencies.