### PR TITLE
Improved integration by using `taskGraph.allTasks`

### DIFF
--- a/demo/module1/build.gradle.kts
+++ b/demo/module1/build.gradle.kts
@@ -2,3 +2,7 @@ plugins {
     `java-library`
     `maven-publish`
 }
+
+tasks.withType<AbstractPublishToMaven>() {
+    enabled = false
+}

--- a/plugin/src/main/kotlin/io/github/gmazzo/publications/report/ReportPublication.kt
+++ b/plugin/src/main/kotlin/io/github/gmazzo/publications/report/ReportPublication.kt
@@ -13,12 +13,6 @@ data class ReportPublication(
 
     data class Repository(val name: String, val value: String): Serializable
 
-    enum class Outcome(text: String? = null) {
-
-        Published, Failed, Skipped, NotRun("not-run"), Unknown;
-
-       val text: String = text ?: name.lowercase()
-
-    }
+    enum class Outcome { Published, Failed, Skipped, Unknown }
 
 }

--- a/plugin/src/main/kotlin/io/github/gmazzo/publications/report/ReportPublicationsFlowAction.kt
+++ b/plugin/src/main/kotlin/io/github/gmazzo/publications/report/ReportPublicationsFlowAction.kt
@@ -25,7 +25,7 @@ abstract class ReportPublicationsFlowAction : FlowAction<ReportPublicationsFlowA
         val outcomes = parameters.outcomes.get()
 
         parameters.publications.get().forEach { (path, pub) ->
-            val outcome = outcomes[path] ?: ReportPublication.Outcome.NotRun
+            val outcome = outcomes[path] ?: pub.outcome
 
             publications.compute(pub.repository) { _, set ->
                 (set ?: TreeSet(publicationsComparator)).apply { add(pub.copy(outcome = outcome)) }
@@ -61,7 +61,7 @@ abstract class ReportPublicationsFlowAction : FlowAction<ReportPublicationsFlowA
                 info.text(it.version)
                 failure.text(it.artifacts.joinToString(prefix = " [", separator = ", ", postfix = "]"))
                 if (it.outcome != ReportPublication.Outcome.Published) {
-                    failureHeader.text(" (${it.outcome.text})")
+                    failureHeader.text(" (${it.outcome.name.lowercase()})")
                 }
                 println()
             }

--- a/plugin/src/test/kotlin/io/github/gmazzo/gradle/publications/report/ReportPublicationsPluginTest.kt
+++ b/plugin/src/test/kotlin/io/github/gmazzo/gradle/publications/report/ReportPublicationsPluginTest.kt
@@ -28,7 +28,7 @@ class ReportPublicationsPluginTest {
              - io.gmazzo.demo.build-logic:otherModule:0.1.0 [jar]
             The following artifacts were published to myRepo(file:$rootDir/publish/build/repo/):
              - io.gmazzo.demo:demo:0.1.0 [jar]
-             - io.gmazzo.demo:module1:0.1.0 [jar]
+             - io.gmazzo.demo:module1:0.1.0 [jar] (skipped)
              - io.gmazzo.demo:module2:0.1.0 [jar]
         """.trimIndent(), result.reportPublicationsOutput
         )
@@ -45,7 +45,7 @@ class ReportPublicationsPluginTest {
             """
             The following artifacts were published to mavenLocal(~/.m2/repository):
              - io.gmazzo.demo:demo:0.1.0 [jar]
-             - io.gmazzo.demo:module1:0.1.0 [jar]
+             - io.gmazzo.demo:module1:0.1.0 [jar] (skipped)
              - io.gmazzo.demo:module2:0.1.0 [jar]
              - io.gmazzo.demo.build-logic:build-logic:0.1.0 [jar]
              - io.gmazzo.demo.build-logic:otherModule:0.1.0 [jar]
@@ -67,11 +67,11 @@ class ReportPublicationsPluginTest {
              - io.gmazzo.demo.build-logic:otherModule:0.1.0 [jar]
             The following artifacts were published to myRepo(file:$rootDir/publish-publishToMavenLocal/build/repo/):
              - io.gmazzo.demo:demo:0.1.0 [jar]
-             - io.gmazzo.demo:module1:0.1.0 [jar]
+             - io.gmazzo.demo:module1:0.1.0 [jar] (skipped)
              - io.gmazzo.demo:module2:0.1.0 [jar]
             The following artifacts were published to mavenLocal(~/.m2/repository):
              - io.gmazzo.demo:demo:0.1.0 [jar]
-             - io.gmazzo.demo:module1:0.1.0 [jar]
+             - io.gmazzo.demo:module1:0.1.0 [jar] (skipped)
              - io.gmazzo.demo:module2:0.1.0 [jar]
              - io.gmazzo.demo.build-logic:build-logic:0.1.0 [jar]
              - io.gmazzo.demo.build-logic:otherModule:0.1.0 [jar]


### PR DESCRIPTION
Dropped the `tasks.configureEach` approach in favor of a more robust one by using `taskGraph.allTasks` to detect Maven publish tasks participating on the build.