### PR TITLE
Fix tests running under windows

### DIFF
--- a/plugin/src/test/kotlin/io/github/gmazzo/gradle/publications/report/ReportPublicationsPluginTest.kt
+++ b/plugin/src/test/kotlin/io/github/gmazzo/gradle/publications/report/ReportPublicationsPluginTest.kt
@@ -1,12 +1,12 @@
 package io.github.gmazzo.gradle.publications.report
 
 import io.github.gmazzo.publications.report.ReportPublicationsPlugin
+import org.gradle.kotlin.dsl.support.normaliseLineSeparators
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.util.GradleVersion
 import java.io.File
-import java.io.PrintWriter
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -26,19 +26,19 @@ sealed class ReportPublicationsPluginTest(private val gradleVersion: String) {
 
         assertEquals(
             """
-            The following artifacts were published to localIvy(file:$rootDir/publish/build/repo/ivy/):
+            The following artifacts were published to localIvy(${rootDir.resolve("publish/build/repo/ivy/").toURI()}):
              - io.gmazzo.demo:demo:0.1.0 [jar]
              - io.gmazzo.demo:module1:0.1.0 [jar]
              - io.gmazzo.demo:module2:0.1.0 [jar]
              - io.gmazzo.demo.build-logic:build-logic:0.1.0 [jar]
              - io.gmazzo.demo.build-logic:otherModule:0.1.0 [jar]
-            The following artifacts were published to localMaven(file:$rootDir/publish/build/repo/maven/):
+            The following artifacts were published to localMaven(${rootDir.resolve("publish/build/repo/maven/").toURI()}):
              - io.gmazzo.demo:demo:0.1.0 [jar]
              - io.gmazzo.demo:module1:0.1.0 [jar] (skipped)
              - io.gmazzo.demo:module2:0.1.0 [jar]
              - io.gmazzo.demo.build-logic:build-logic:0.1.0 [jar]
              - io.gmazzo.demo.build-logic:otherModule:0.1.0 [jar]
-        """.trimIndent(), result.reportPublicationsOutput
+        """.trimIndent(), result.reportPublicationsOutput?.normaliseLineSeparators()
         )
     }
 
@@ -57,7 +57,7 @@ sealed class ReportPublicationsPluginTest(private val gradleVersion: String) {
              - io.gmazzo.demo:module2:0.1.0 [jar]
              - io.gmazzo.demo.build-logic:build-logic:0.1.0 [jar]
              - io.gmazzo.demo.build-logic:otherModule:0.1.0 [jar]
-        """.trimIndent(), result.reportPublicationsOutput
+        """.trimIndent(), result.reportPublicationsOutput?.normaliseLineSeparators()
         )
     }
 
@@ -70,13 +70,13 @@ sealed class ReportPublicationsPluginTest(private val gradleVersion: String) {
 
         assertEquals(
             """
-            The following artifacts were published to localIvy(file:$rootDir/publish-publishToMavenLocal/build/repo/ivy/):
+            The following artifacts were published to localIvy(${rootDir.resolve("publish-publishToMavenLocal/build/repo/ivy/").toURI()}):
              - io.gmazzo.demo:demo:0.1.0 [jar]
              - io.gmazzo.demo:module1:0.1.0 [jar]
              - io.gmazzo.demo:module2:0.1.0 [jar]
              - io.gmazzo.demo.build-logic:build-logic:0.1.0 [jar]
              - io.gmazzo.demo.build-logic:otherModule:0.1.0 [jar]
-            The following artifacts were published to localMaven(file:$rootDir/publish-publishToMavenLocal/build/repo/maven/):
+            The following artifacts were published to localMaven(${rootDir.resolve("publish-publishToMavenLocal/build/repo/maven/").toURI()}):
              - io.gmazzo.demo:demo:0.1.0 [jar]
              - io.gmazzo.demo:module1:0.1.0 [jar] (skipped)
              - io.gmazzo.demo:module2:0.1.0 [jar]
@@ -88,7 +88,7 @@ sealed class ReportPublicationsPluginTest(private val gradleVersion: String) {
              - io.gmazzo.demo:module2:0.1.0 [jar]
              - io.gmazzo.demo.build-logic:build-logic:0.1.0 [jar]
              - io.gmazzo.demo.build-logic:otherModule:0.1.0 [jar]
-        """.trimIndent(), result.reportPublicationsOutput
+        """.trimIndent(), result.reportPublicationsOutput?.normaliseLineSeparators()
         )
     }
 


### PR DESCRIPTION
The tests currently fail on windows due to file paths and line ending differences. I'm using `File::toURI()` as `URI::toString()` is what's used in the rendering of the report.